### PR TITLE
Fix compatibility with osu! 2026.819.0 Tachyon

### DIFF
--- a/osu.Game.Rulesets.Sticks/Edit/SticksCompositionTools.cs
+++ b/osu.Game.Rulesets.Sticks/Edit/SticksCompositionTools.cs
@@ -2,12 +2,17 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Edit;
-using osu.Game.Rulesets.Edit.Tools;
 using osu.Game.Rulesets.Sticks.Edit.Blueprints;
+
+#if STICKS_RULESET_API_2026_818
+using SticksCompositionTool = osu.Game.Rulesets.Edit.Tools.CompositionTool<osu.Game.Rulesets.Sticks.SticksAction>;
+#else
+using SticksCompositionTool = osu.Game.Rulesets.Edit.Tools.CompositionTool;
+#endif
 
 namespace osu.Game.Rulesets.Sticks.Edit
 {
-    public class SticksFlickCompositionTool : CompositionTool
+    public class SticksFlickCompositionTool : SticksCompositionTool
     {
         public SticksFlickCompositionTool()
             : base("Flick")
@@ -20,7 +25,7 @@ namespace osu.Game.Rulesets.Sticks.Edit
         public override HitObjectPlacementBlueprint CreatePlacementBlueprint() => new SticksFlickPlacementBlueprint();
     }
 
-    public class SticksHoldCompositionTool : CompositionTool
+    public class SticksHoldCompositionTool : SticksCompositionTool
     {
         public SticksHoldCompositionTool()
             : base("Hold")
@@ -33,7 +38,7 @@ namespace osu.Game.Rulesets.Sticks.Edit
         public override HitObjectPlacementBlueprint CreatePlacementBlueprint() => new SticksHoldPlacementBlueprint();
     }
 
-    public class SticksSliderCompositionTool : CompositionTool
+    public class SticksSliderCompositionTool : SticksCompositionTool
     {
         public SticksSliderCompositionTool()
             : base("Slider")

--- a/osu.Game.Rulesets.Sticks/Edit/SticksHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Sticks/Edit/SticksHitObjectComposer.cs
@@ -1,11 +1,20 @@
+#nullable enable
+
 using System.Collections.Generic;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Edit;
-using osu.Game.Rulesets.Edit.Tools;
 using osu.Game.Rulesets.Sticks.Objects;
 using osu.Game.Screens.Edit.Compose.Components;
 using osuTK;
+
+#if STICKS_RULESET_API_2026_818
+using SticksCompositionTool = osu.Game.Rulesets.Edit.Tools.CompositionTool<osu.Game.Rulesets.Sticks.SticksAction>;
+#else
+using SticksCompositionTool = osu.Game.Rulesets.Edit.Tools.CompositionTool;
+#endif
 
 namespace osu.Game.Rulesets.Sticks.Edit
 {
@@ -22,7 +31,11 @@ namespace osu.Game.Rulesets.Sticks.Edit
         {
         }
 
-        protected override IReadOnlyList<CompositionTool> CompositionTools => new CompositionTool[]
+#if STICKS_RULESET_API_2026_818
+        public override Bindable<TernaryState>? SelectionNewComboState => null;
+#endif
+
+        protected override IReadOnlyList<SticksCompositionTool> CompositionTools => new SticksCompositionTool[]
         {
             new SticksFlickCompositionTool(),
             new SticksHoldCompositionTool(),

--- a/osu.Game.Rulesets.Sticks/SticksRuleset.cs
+++ b/osu.Game.Rulesets.Sticks/SticksRuleset.cs
@@ -166,11 +166,7 @@ namespace osu.Game.Rulesets.Sticks
 
             return new[]
             {
-                new StatisticItem("Performance Breakdown", () => new PerformanceBreakdownChart(score, playableBeatmap)
-                {
-                    RelativeSizeAxes = Axes.X,
-                    AutoSizeAxes = Axes.Y,
-                }),
+                new StatisticItem("Performance Breakdown", () => createPerformanceBreakdownChart(score, playableBeatmap)),
                 new StatisticItem("Timing Distribution", () => new HitEventTimingDistributionGraph(summary.TimingEvents)
                 {
                     RelativeSizeAxes = Axes.X,
@@ -246,6 +242,21 @@ namespace osu.Game.Rulesets.Sticks
         private static string formatDegrees(double? value) => value.HasValue ? $"{value.Value:0.0}°" : "N/A";
 
         private static string formatCompletion(int hits, int total) => total > 0 ? $"{(double)hits / total:P1}" : "N/A";
+
+        private static PerformanceBreakdownChart createPerformanceBreakdownChart(ScoreInfo score, IBeatmap playableBeatmap)
+        {
+            PerformanceBreakdownChart chart;
+
+#if STICKS_RULESET_API_2026_818
+            chart = new PerformanceBreakdownChart(score);
+#else
+            chart = new PerformanceBreakdownChart(score, playableBeatmap);
+#endif
+
+            chart.RelativeSizeAxes = Axes.X;
+            chart.AutoSizeAxes = Axes.Y;
+            return chart;
+        }
 
         public override IEnumerable<KeyBinding> GetDefaultKeyBindings(int variant = 0) => new[]
         {


### PR DESCRIPTION
## Summary

- adapt Sticks editor composition tools to the generic action API introduced by ruleset API 2026.818.0
- explicitly disable new-combo selection state because Sticks objects do not use combo semantics
- use the new performance breakdown constructor while retaining stable lazer compatibility

## Compatibility targets

- 2026.804.2-lazer
- 2026.819.0-tachyon

## Verification

- Release solution tests against official 2026.804.2-lazer source: 290 passed
- Release solution tests against official 2026.819.0-tachyon source: 290 passed