### PR TITLE
Publish efficient osu! compatibility releases

### DIFF
--- a/.github/scripts/Resolve-OsuCompatibility.ps1
+++ b/.github/scripts/Resolve-OsuCompatibility.ps1
@@ -1,0 +1,125 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $Repository,
+    [string] $GitHubToken,
+    [bool] $Force = $false,
+    [Parameter(Mandatory = $true)]
+    [string] $GitHubOutput
+)
+
+$ErrorActionPreference = "Stop"
+
+$headers = @{
+    Accept = "application/vnd.github+json"
+    "X-GitHub-Api-Version" = "2022-11-28"
+}
+
+if (-not [string]::IsNullOrWhiteSpace($GitHubToken)) {
+    $headers.Authorization = "Bearer $GitHubToken"
+}
+
+function Get-RulesetApiVersion([string] $tag) {
+    $encodedRef = [Uri]::EscapeDataString($tag)
+    $response = Invoke-RestMethod -Headers $headers -Uri "https://api.github.com/repos/ppy/osu/contents/osu.Game/Rulesets/Ruleset.cs?ref=$encodedRef"
+    $encodedContent = $response.content -replace '\s', ''
+    $source = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($encodedContent))
+    $match = [regex]::Match($source, 'CURRENT_RULESET_API_VERSION\s*=\s*"(?<version>[^"]+)"')
+
+    if (-not $match.Success) {
+        throw "Could not read CURRENT_RULESET_API_VERSION from $tag."
+    }
+
+    return [Version]::Parse($match.Groups['version'].Value)
+}
+
+function Get-NextSuffix([string] $suffix) {
+    if ([string]::IsNullOrEmpty($suffix)) {
+        return "a"
+    }
+
+    $characters = $suffix.ToCharArray()
+
+    for ($i = $characters.Length - 1; $i -ge 0; $i--) {
+        if ($characters[$i] -ne 'z') {
+            $characters[$i] = [char]([int]$characters[$i] + 1)
+            return -join $characters
+        }
+
+        $characters[$i] = 'a'
+    }
+
+    return "a$(-join $characters)"
+}
+
+$osuReleases = Invoke-RestMethod -Headers $headers -Uri "https://api.github.com/repos/ppy/osu/releases?per_page=40"
+$lazerRelease = $osuReleases | Where-Object { $_.tag_name.EndsWith("-lazer") } | Select-Object -First 1
+$tachyonRelease = $osuReleases | Where-Object { $_.tag_name.EndsWith("-tachyon") } | Select-Object -First 1
+
+if ($null -eq $lazerRelease -or $null -eq $tachyonRelease) {
+    throw "Could not find both official osu! lazer and Tachyon releases."
+}
+
+$lazerApi = Get-RulesetApiVersion $lazerRelease.tag_name
+$tachyonApi = Get-RulesetApiVersion $tachyonRelease.tag_name
+$sticksRelease = Invoke-RestMethod -Headers $headers -Uri "https://api.github.com/repos/$Repository/releases/latest"
+$assetNames = @($sticksRelease.assets | ForEach-Object { $_.name })
+$lazerAsset = "osu.Game.Rulesets.Sticks-$($lazerRelease.tag_name).dll"
+$tachyonAsset = "osu.Game.Rulesets.Sticks-$($tachyonRelease.tag_name).dll"
+$targets = [Collections.Generic.List[object]]::new()
+
+if ($Force -or $assetNames -notcontains $lazerAsset -or $assetNames -notcontains "$lazerAsset.sha256") {
+    $targets.Add([ordered]@{
+        name = "Latest stable lazer"
+        channel = "lazer"
+        tag = $lazerRelease.tag_name
+        client_version = ($lazerRelease.tag_name -replace '-lazer$', '')
+        api_version = $lazerApi.ToString()
+        asset_name = $lazerAsset
+    })
+}
+
+if ($Force -or $assetNames -notcontains $tachyonAsset -or $assetNames -notcontains "$tachyonAsset.sha256") {
+    $targets.Add([ordered]@{
+        name = "Latest Tachyon canary"
+        channel = "tachyon"
+        tag = $tachyonRelease.tag_name
+        client_version = ($tachyonRelease.tag_name -replace '-tachyon$', '')
+        api_version = $tachyonApi.ToString()
+        asset_name = $tachyonAsset
+    })
+}
+
+$tagMatch = [regex]::Match($sticksRelease.tag_name, '^v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(?<suffix>[a-z]*)$')
+
+if (-not $tagMatch.Success) {
+    throw "Latest Sticks release tag does not support automatic letter versioning: $($sticksRelease.tag_name)"
+}
+
+$nextSuffix = Get-NextSuffix $tagMatch.Groups['suffix'].Value
+$baseVersion = "$($tagMatch.Groups['major'].Value).$($tagMatch.Groups['minor'].Value).$($tagMatch.Groups['patch'].Value)"
+$releaseTag = "v$baseVersion$nextSuffix"
+$rulesetVersion = "$baseVersion$nextSuffix"
+$assemblyVersion = "$baseVersion.0"
+$matrix = @{ include = $targets.ToArray() } | ConvertTo-Json -Depth 5 -Compress
+$hasChanges = ($targets.Count -gt 0).ToString().ToLowerInvariant()
+
+"has_changes=$hasChanges" | Out-File -FilePath $GitHubOutput -Encoding utf8 -Append
+"matrix=$matrix" | Out-File -FilePath $GitHubOutput -Encoding utf8 -Append
+"previous_release_tag=$($sticksRelease.tag_name)" | Out-File -FilePath $GitHubOutput -Encoding utf8 -Append
+"release_tag=$releaseTag" | Out-File -FilePath $GitHubOutput -Encoding utf8 -Append
+"ruleset_version=$rulesetVersion" | Out-File -FilePath $GitHubOutput -Encoding utf8 -Append
+"assembly_version=$assemblyVersion" | Out-File -FilePath $GitHubOutput -Encoding utf8 -Append
+"lazer_tag=$($lazerRelease.tag_name)" | Out-File -FilePath $GitHubOutput -Encoding utf8 -Append
+"tachyon_tag=$($tachyonRelease.tag_name)" | Out-File -FilePath $GitHubOutput -Encoding utf8 -Append
+"lazer_api=$lazerApi" | Out-File -FilePath $GitHubOutput -Encoding utf8 -Append
+"tachyon_api=$tachyonApi" | Out-File -FilePath $GitHubOutput -Encoding utf8 -Append
+"lazer_asset=$lazerAsset" | Out-File -FilePath $GitHubOutput -Encoding utf8 -Append
+"tachyon_asset=$tachyonAsset" | Out-File -FilePath $GitHubOutput -Encoding utf8 -Append
+
+if ($targets.Count -eq 0) {
+    Write-Host "Latest release $($sticksRelease.tag_name) already contains $lazerAsset and $tachyonAsset. No compatibility build is needed."
+}
+else {
+    Write-Host "Compatibility build required for: $($targets.tag -join ', '). Next automatic release: $releaseTag"
+}

--- a/.github/scripts/Test-ObsoleteCompatibilityBranches.ps1
+++ b/.github/scripts/Test-ObsoleteCompatibilityBranches.ps1
@@ -1,0 +1,30 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [Version] $LazerApi,
+    [Parameter(Mandatory = $true)]
+    [Version] $TachyonApi,
+    [string] $ProjectPath = ".\osu.Game.Rulesets.Sticks"
+)
+
+$boundaries = @(
+    @{
+        Symbol = "STICKS_RULESET_API_2026_818"
+        MinimumApi = [Version]::Parse("2026.818.0")
+    }
+)
+$sourceFiles = Get-ChildItem -LiteralPath $ProjectPath -Recurse -File |
+    Where-Object { $_.Extension -in ".cs", ".csproj", ".props", ".targets" }
+
+foreach ($boundary in $boundaries) {
+    if ($LazerApi -lt $boundary.MinimumApi -or $TachyonApi -lt $boundary.MinimumApi) {
+        continue
+    }
+
+    $matches = @($sourceFiles | Select-String -SimpleMatch $boundary.Symbol)
+
+    if ($matches.Count -gt 0) {
+        $locations = $matches | ForEach-Object { "$($_.Path):$($_.LineNumber)" }
+        throw "Compatibility conditional $($boundary.Symbol) is obsolete for lazer $LazerApi and Tachyon $TachyonApi. Remove both branches and the associated build property. Found at: $($locations -join ', ')"
+    }
+}

--- a/.github/workflows/osu-compatibility.yml
+++ b/.github/workflows/osu-compatibility.yml
@@ -4,6 +4,17 @@ on:
   schedule:
     - cron: "23 9 * * *"
   workflow_dispatch:
+    inputs:
+      force:
+        description: Build both channels even when the current release already contains them
+        required: false
+        default: false
+        type: boolean
+      publish_release:
+        description: Publish the normal lettered release after successful builds
+        required: false
+        default: true
+        type: boolean
 
 permissions:
   contents: read
@@ -17,52 +28,62 @@ env:
   DOTNET_NOLOGO: "true"
 
 jobs:
-  compatibility:
-    name: ${{ matrix.name }}
-    runs-on: windows-latest
-    timeout-minutes: 45
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: Latest stable lazer
-            channel: lazer
-          - name: Latest Tachyon canary
-            channel: tachyon
+  check_releases:
+    name: Check official release versions
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      has_changes: ${{ steps.release_check.outputs.has_changes }}
+      matrix: ${{ steps.release_check.outputs.matrix }}
+      previous_release_tag: ${{ steps.release_check.outputs.previous_release_tag }}
+      release_tag: ${{ steps.release_check.outputs.release_tag }}
+      ruleset_version: ${{ steps.release_check.outputs.ruleset_version }}
+      assembly_version: ${{ steps.release_check.outputs.assembly_version }}
+      lazer_tag: ${{ steps.release_check.outputs.lazer_tag }}
+      tachyon_tag: ${{ steps.release_check.outputs.tachyon_tag }}
+      lazer_api: ${{ steps.release_check.outputs.lazer_api }}
+      tachyon_api: ${{ steps.release_check.outputs.tachyon_api }}
+      lazer_asset: ${{ steps.release_check.outputs.lazer_asset }}
+      tachyon_asset: ${{ steps.release_check.outputs.tachyon_asset }}
 
     steps:
       - name: Check out Sticks
         uses: actions/checkout@v6
 
-      - name: Find latest official ${{ matrix.channel }} release
-        id: osu-release
+      - name: Find changed official releases
+        id: release_check
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
-          CHANNEL: ${{ matrix.channel }}
-        run: |
-          $headers = @{
-              Authorization = "Bearer $env:GH_TOKEN"
-              Accept = "application/vnd.github+json"
-              "X-GitHub-Api-Version" = "2022-11-28"
-          }
+          FORCE: ${{ github.event_name == 'workflow_dispatch' && inputs.force || false }}
+        run: .\.github\scripts\Resolve-OsuCompatibility.ps1 -Repository $env:GITHUB_REPOSITORY -GitHubToken $env:GH_TOKEN -Force:($env:FORCE -eq "true") -GitHubOutput $env:GITHUB_OUTPUT
 
-          $releases = Invoke-RestMethod -Headers $headers -Uri "https://api.github.com/repos/ppy/osu/releases?per_page=40"
-          $release = $releases | Where-Object { $_.tag_name.EndsWith("-$env:CHANNEL") } | Select-Object -First 1
+      - name: Reject obsolete compatibility branches
+        shell: pwsh
+        env:
+          LAZER_API: ${{ steps.release_check.outputs.lazer_api }}
+          TACHYON_API: ${{ steps.release_check.outputs.tachyon_api }}
+        run: .\.github\scripts\Test-ObsoleteCompatibilityBranches.ps1 -LazerApi $env:LAZER_API -TachyonApi $env:TACHYON_API
 
-          if ($null -eq $release) {
-              throw "Could not find an official osu! $env:CHANNEL release."
-          }
+  compatibility:
+    name: ${{ matrix.name }}
+    needs: check_releases
+    if: needs.check_releases.outputs.has_changes == 'true'
+    runs-on: windows-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.check_releases.outputs.matrix) }}
 
-          "tag=$($release.tag_name)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-          "client-version=$($release.tag_name -replace '-(lazer|tachyon)$', '')" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-          Write-Host "Testing against $($release.tag_name)"
+    steps:
+      - name: Check out Sticks
+        uses: actions/checkout@v6
 
       - name: Check out official osu! source
         uses: actions/checkout@v6
         with:
           repository: ppy/osu
-          ref: ${{ steps.osu-release.outputs.tag }}
+          ref: ${{ matrix.tag }}
           path: upstream-osu
           fetch-depth: 1
 
@@ -71,8 +92,10 @@ jobs:
         with:
           dotnet-version: "8.0.x"
 
-      - name: Detect ruleset API generation
+      - name: Verify ruleset API generation
         shell: pwsh
+        env:
+          EXPECTED_API: ${{ matrix.api_version }}
         run: |
           $rulesetSource = Get-Content -Raw -LiteralPath ".\upstream-osu\osu.Game\Rulesets\Ruleset.cs"
           $match = [regex]::Match($rulesetSource, 'CURRENT_RULESET_API_VERSION\s*=\s*"(?<version>[^"]+)"')
@@ -82,7 +105,9 @@ jobs:
           }
 
           $apiVersion = [Version]::Parse($match.Groups['version'].Value)
-          "OSU_RULESET_API=$apiVersion" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          if ($apiVersion -ne [Version]::Parse($env:EXPECTED_API)) {
+              throw "Preflight detected ruleset API $env:EXPECTED_API but checked-out source contains $apiVersion."
+          }
 
           if ($apiVersion -ge [Version]::Parse("2026.818.0")) {
               "STICKS_NEW_RULESET_API=true" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
@@ -93,7 +118,11 @@ jobs:
         run: |
           $properties = @(
               "-p:OsuSourceRoot=$env:GITHUB_WORKSPACE\upstream-osu"
-              "-p:OsuClientVersion=${{ steps.osu-release.outputs.client-version }}"
+              "-p:OsuClientVersion=${{ matrix.client_version }}"
+              "-p:AssemblyVersion=${{ needs.check_releases.outputs.assembly_version }}"
+              "-p:FileVersion=${{ needs.check_releases.outputs.assembly_version }}"
+              "-p:InformationalVersion=${{ needs.check_releases.outputs.ruleset_version }}"
+              "-p:IncludeSourceRevisionInInformationalVersion=false"
           )
           if ($env:STICKS_NEW_RULESET_API) {
               $properties += "-p:SticksRulesetApi2026818=true"
@@ -101,12 +130,16 @@ jobs:
 
           dotnet restore .\osu.Game.Rulesets.Sticks.sln @properties
 
-      - name: Build and test against ${{ steps.osu-release.outputs.tag }}
+      - name: Build and test against ${{ matrix.tag }}
         shell: pwsh
         run: |
           $properties = @(
               "-p:OsuSourceRoot=$env:GITHUB_WORKSPACE\upstream-osu"
-              "-p:OsuClientVersion=${{ steps.osu-release.outputs.client-version }}"
+              "-p:OsuClientVersion=${{ matrix.client_version }}"
+              "-p:AssemblyVersion=${{ needs.check_releases.outputs.assembly_version }}"
+              "-p:FileVersion=${{ needs.check_releases.outputs.assembly_version }}"
+              "-p:InformationalVersion=${{ needs.check_releases.outputs.ruleset_version }}"
+              "-p:IncludeSourceRevisionInInformationalVersion=false"
           )
           if ($env:STICKS_NEW_RULESET_API) {
               $properties += "-p:SticksRulesetApi2026818=true"
@@ -114,10 +147,128 @@ jobs:
 
           dotnet test .\osu.Game.Rulesets.Sticks.sln --configuration Release --no-restore @properties
 
-      - name: Upload compatible DLL
+      - name: Stage compatible DLL
+        shell: pwsh
+        env:
+          ASSET_NAME: ${{ matrix.asset_name }}
+          ASSEMBLY_VERSION: ${{ needs.check_releases.outputs.assembly_version }}
+          RULESET_VERSION: ${{ needs.check_releases.outputs.ruleset_version }}
+        run: |
+          $source = ".\osu.Game.Rulesets.Sticks\bin\Release\net8.0\osu.Game.Rulesets.Sticks.dll"
+          $output = ".\compatibility-release"
+          $dll = Join-Path $output $env:ASSET_NAME
+
+          if (-not (Test-Path -LiteralPath $source -PathType Leaf)) {
+              throw "Expected compatible DLL was not produced: $source"
+          }
+
+          New-Item -ItemType Directory -Path $output -Force | Out-Null
+          Copy-Item -LiteralPath $source -Destination $dll -Force
+
+          $assemblyVersion = [System.Reflection.AssemblyName]::GetAssemblyName((Resolve-Path -LiteralPath $dll)).Version
+          if ($assemblyVersion -ne [Version]::Parse($env:ASSEMBLY_VERSION)) {
+              throw "Compatibility DLL assembly version $assemblyVersion does not match $env:ASSEMBLY_VERSION."
+          }
+
+          $informationalVersion = [System.Diagnostics.FileVersionInfo]::GetVersionInfo((Resolve-Path -LiteralPath $dll)).ProductVersion
+          if ($informationalVersion -ne $env:RULESET_VERSION) {
+              throw "Compatibility DLL informational version '$informationalVersion' does not match '$env:RULESET_VERSION'."
+          }
+
+          $hash = (Get-FileHash -LiteralPath $dll -Algorithm SHA256).Hash.ToLowerInvariant()
+          "$hash  $env:ASSET_NAME" | Set-Content -LiteralPath "$dll.sha256" -Encoding utf8NoBOM
+
+      - name: Transfer compatible DLL to release job
         uses: actions/upload-artifact@v6
         with:
-          name: Sticks-${{ steps.osu-release.outputs.tag }}
-          path: osu.Game.Rulesets.Sticks/bin/Release/net8.0/osu.Game.Rulesets.Sticks.dll
+          name: compatibility-${{ matrix.channel }}
+          path: compatibility-release/*
           if-no-files-found: error
-          retention-days: 14
+          retention-days: 1
+
+  publish_release:
+    name: Publish automatic compatibility release
+    needs:
+      - check_releases
+      - compatibility
+    if: ${{ always() && needs.check_releases.outputs.has_changes == 'true' && needs.compatibility.result == 'success' && (github.event_name != 'workflow_dispatch' || inputs.publish_release) }}
+    permissions:
+      contents: write
+    runs-on: windows-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out Sticks
+        uses: actions/checkout@v6
+
+      - name: Download newly built DLLs
+        uses: actions/download-artifact@v8
+        with:
+          pattern: compatibility-*
+          path: compatibility-release
+          merge-multiple: true
+
+      - name: Carry forward unchanged DLLs
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PREVIOUS_RELEASE_TAG: ${{ needs.check_releases.outputs.previous_release_tag }}
+          LAZER_ASSET: ${{ needs.check_releases.outputs.lazer_asset }}
+          TACHYON_ASSET: ${{ needs.check_releases.outputs.tachyon_asset }}
+        run: |
+          $output = ".\compatibility-release"
+          New-Item -ItemType Directory -Path $output -Force | Out-Null
+
+          foreach ($assetName in @($env:LAZER_ASSET, $env:TACHYON_ASSET)) {
+              $dll = Join-Path $output $assetName
+
+              if (-not (Test-Path -LiteralPath $dll -PathType Leaf)) {
+                  gh release download $env:PREVIOUS_RELEASE_TAG --pattern $assetName --dir $output
+                  if ($LASTEXITCODE -ne 0) {
+                      throw "Could not carry $assetName forward from $env:PREVIOUS_RELEASE_TAG."
+                  }
+
+                  gh release download $env:PREVIOUS_RELEASE_TAG --pattern "$assetName.sha256" --dir $output
+                  if ($LASTEXITCODE -ne 0) {
+                      throw "Could not carry $assetName.sha256 forward from $env:PREVIOUS_RELEASE_TAG."
+                  }
+              }
+          }
+
+          Copy-Item -LiteralPath ".\LICENSE.md" -Destination $output -Force
+          Copy-Item -LiteralPath ".\THIRD_PARTY_NOTICES.md" -Destination $output -Force
+
+      - name: Create normal GitHub Release
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.check_releases.outputs.release_tag }}
+          RULESET_VERSION: ${{ needs.check_releases.outputs.ruleset_version }}
+          LAZER_TAG: ${{ needs.check_releases.outputs.lazer_tag }}
+          TACHYON_TAG: ${{ needs.check_releases.outputs.tachyon_tag }}
+        run: |
+          $assets = @(Get-ChildItem -LiteralPath ".\compatibility-release" -File | ForEach-Object { $_.FullName })
+          $notes = @"
+          Automatic compatibility build for the newest official osu! releases:
+
+          - stable lazer: $env:LAZER_TAG
+          - Tachyon: $env:TACHYON_TAG
+
+          Download the DLL matching the osu! channel you use. This is a normal release; the letter suffix identifies an automatic compatibility build and numeric version changes remain reserved for ruleset updates.
+
+          A channel whose upstream tag did not change is carried forward from the previous tested release without rebuilding.
+          "@
+
+          gh release view $env:RELEASE_TAG --json tagName *> $null
+          $releaseExists = $LASTEXITCODE -eq 0
+
+          if ($releaseExists) {
+              gh release upload $env:RELEASE_TAG @assets --clobber
+          }
+          else {
+              gh release create $env:RELEASE_TAG @assets --target $env:GITHUB_SHA --title "Sticks $env:RELEASE_TAG" --notes $notes --latest
+          }
+
+          if ($LASTEXITCODE -ne 0) {
+              throw "Failed to publish automatic compatibility release $env:RELEASE_TAG."
+          }

--- a/README.md
+++ b/README.md
@@ -43,9 +43,11 @@ osu.Game.Rulesets.Sticks\bin\Release\net8.0\osu.Game.Rulesets.Sticks.dll
 
 Use **Settings → Open osu! folder** if you do not know where lazer's data folder is.
 
-## Tagged releases
+## Releases
 
-Pushing a tag beginning with `v` runs the full test suite and creates or updates the matching GitHub Release. The release contains the directly installable `osu.Game.Rulesets.Sticks.dll` and its SHA-256 checksum.
+Pushing a tag beginning with `v` runs the full test suite and creates or updates the matching normal GitHub Release. Numeric versions such as `v1.0.7` are reserved for ruleset updates. The daily compatibility workflow checks the newest official stable lazer and Tachyon tags before building; when either changes, it tests only the changed channel and publishes the next lettered normal release, such as `v1.0.6a` or `v1.0.6b`.
+
+Automatic compatibility releases contain a separately named DLL and SHA-256 checksum for each supported osu! channel. Download the DLL whose filename matches your lazer or Tachyon release. When only one upstream channel changes, the other channel's already-tested DLL is carried forward without rebuilding.
 
 ```powershell
 git tag v0.1.0


### PR DESCRIPTION
## Summary

- check official lazer and Tachyon tags before any upstream clone, restore, or build
- build only channels missing from the latest normal Sticks release
- publish automatic compatibility builds as normal letter-suffixed releases such as v1.0.6a
- carry unchanged channel DLLs forward without rebuilding
- fail when a registered compatibility #if is no longer required by either current target
- document numeric versus automatic letter versioning

## Verification

- preflight resolved 2026.804.2-lazer / API 2022.822.0 and 2026.819.0-tachyon / API 2026.818.0
- preflight selected v1.0.6a and only assets missing from v1.0.6
- obsolete-conditional guard accepts the current split APIs and rejects a simulated both-new-API state
- Release tests against official 2026.804.2-lazer source: 290 passed
- Release tests against official 2026.819.0-tachyon source: 290 passed
- both output DLLs report assembly 1.0.6.0 and informational version 1.0.6a