### PR TITLE
Fix scheduled osu compatibility releases

### DIFF
--- a/.github/scripts/Resolve-OsuCompatibility.ps1
+++ b/.github/scripts/Resolve-OsuCompatibility.ps1
@@ -100,8 +100,8 @@ if (-not $tagMatch.Success) {
 }
 
 $baseVersion = "$($tagMatch.Groups['major'].Value).$($tagMatch.Groups['minor'].Value).$($tagMatch.Groups['patch'].Value)"
-$releaseTag = if ($isTagRelease) { $ReleaseTag } else { "v$baseVersion$(Get-NextSuffix $tagMatch.Groups['suffix'].Value)" }
-$rulesetVersion = $releaseTag -replace '^v', ''
+$resolvedReleaseTag = if ($isTagRelease) { $ReleaseTag } else { "v$baseVersion$(Get-NextSuffix $tagMatch.Groups['suffix'].Value)" }
+$rulesetVersion = $resolvedReleaseTag -replace '^v', ''
 $assemblyVersion = "$baseVersion.0"
 $matrix = @{ include = $targets.ToArray() } | ConvertTo-Json -Depth 5 -Compress
 $hasChanges = ($targets.Count -gt 0).ToString().ToLowerInvariant()
@@ -109,7 +109,7 @@ $hasChanges = ($targets.Count -gt 0).ToString().ToLowerInvariant()
 "has_changes=$hasChanges" | Out-File -FilePath $GitHubOutput -Encoding utf8 -Append
 "matrix=$matrix" | Out-File -FilePath $GitHubOutput -Encoding utf8 -Append
 "previous_release_tag=$($sticksRelease.tag_name)" | Out-File -FilePath $GitHubOutput -Encoding utf8 -Append
-"release_tag=$releaseTag" | Out-File -FilePath $GitHubOutput -Encoding utf8 -Append
+"release_tag=$resolvedReleaseTag" | Out-File -FilePath $GitHubOutput -Encoding utf8 -Append
 "ruleset_version=$rulesetVersion" | Out-File -FilePath $GitHubOutput -Encoding utf8 -Append
 "assembly_version=$assemblyVersion" | Out-File -FilePath $GitHubOutput -Encoding utf8 -Append
 "lazer_tag=$($lazerRelease.tag_name)" | Out-File -FilePath $GitHubOutput -Encoding utf8 -Append
@@ -124,8 +124,8 @@ if ($targets.Count -eq 0) {
     Write-Host "Latest release $($sticksRelease.tag_name) already contains $lazerAsset and $tachyonAsset. No compatibility build is needed."
 }
 elseif ($isTagRelease) {
-    Write-Host "Compatibility build required for new tagged release ${releaseTag}: $($targets.tag -join ', ')"
+    Write-Host "Compatibility build required for new tagged release ${resolvedReleaseTag}: $($targets.tag -join ', ')"
 }
 else {
-    Write-Host "Compatibility build required for: $($targets.tag -join ', '). Next automatic release: $releaseTag"
+    Write-Host "Compatibility build required for: $($targets.tag -join ', '). Next automatic release: $resolvedReleaseTag"
 }

--- a/osu.Game.Rulesets.Sticks/Edit/SticksBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Sticks/Edit/SticksBlueprintContainer.cs
@@ -24,12 +24,14 @@ namespace osu.Game.Rulesets.Sticks.Edit
             AddInternal(new SticksEditorGuide());
         }
 
+#if !STICKS_RULESET_API_2026_818
         protected override Drawable? CreateNewComboButton() => null;
 
         protected override IEnumerable<Drawable> CreateTernaryButtons()
         {
             yield break;
         }
+#endif
 
         protected override SelectionHandler<HitObject> CreateSelectionHandler() => new SticksSelectionHandler();
 


### PR DESCRIPTION
## Summary
- keep scheduled compatibility builds on the triggering commit instead of a not-yet-created release tag
- retain removed editor blueprint overrides only for the older stable API branch

## Validation
- preflight resolves stable 2026.804.2-lazer / API 2022.822.0 and Tachyon 2026.821.0-tachyon / API 2026.818.0
- Release suite: 300 passed on stable
- Release suite: 300 passed on Tachyon
- obsolete-compatibility guard passes for current targets and rejects a simulated both-new target set